### PR TITLE
去掉106行的逗号，否则会报错跑不起来

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,7 @@ if (isDev) {
         })
     });
     config.plugins.push(
-        new ExtractPlugin('styles.[contentHash:8].css'),
+        new ExtractPlugin('styles.[contentHash:8].css')
 
         // // 将类库文件单独打包出来
         // new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
webpack.config.js
报错信息：
```

/Users/zhangbing/Downloads/code/Vue-Webpack-TodoAPP-master/webpack.config.js:117
    );
    ^
SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at WEBPACK_OPTIONS (/Users/zhangbing/Downloads/code/Vue-Webpack-TodoAPP-master/node_modules/webpack-cli/bin/convert-argv.js:133:13)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! vue-webpack-todo@1.0.0 dev: `cross-env NODE_ENV=development webpack-dev-server --mode development --config webpack.config.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the vue-webpack-todo@1.0.0 dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/zhangbing/.npm/_logs/2018-04-27T16_48_34_795Z-debug.log
```